### PR TITLE
Re add php 5.4 for 3.0.* release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/php-code-coverage": "~2.0 || ~3.0",


### PR DESCRIPTION
There is no compatibility issue with php 5.4, as the original 3.0.0 was compatible with php 5.4, i propose to  keep 3.0.* compatible with php 5.4.