### PR TITLE
Fixed 500 error when DESC syntax is used in query

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -36,6 +36,7 @@ class Parser
 
         // MySQL Utility Statements
         'DESCRIBE'          => 'SqlParser\\Statements\\ExplainStatement',
+        'DESC'              => 'SqlParser\\Statements\\ExplainStatement',
         'EXPLAIN'           => 'SqlParser\\Statements\\ExplainStatement',
         'FLUSH'             => '',
         'GRANT'             => '',


### PR DESCRIPTION
Fix for 500 error caused when the statement starts with DESC with is an abbreviation for DESCRIBE